### PR TITLE
Fix playback position reset before playing

### DIFF
--- a/src/pages/[station]/[timestamp].astro
+++ b/src/pages/[station]/[timestamp].astro
@@ -409,6 +409,7 @@ const description = `Luister ${showName} van ${showDate.toLocaleDateString("NL",
 
   playIconContainer.addEventListener("click", () => {
     if (audio.paused) {
+      audio.currentTime = Number(seekSlider.value);
       audio.play();
       raf = requestAnimationFrame(whilePlaying);
     } else {

--- a/src/pages/[station]/[timestamp].astro
+++ b/src/pages/[station]/[timestamp].astro
@@ -1,6 +1,6 @@
 ---
 import Layout from "../../layouts/Layout.astro";
-import { decode } from 'html-entities';
+import { decode } from "html-entities";
 const { station, timestamp } = Astro.params;
 
 interface StationConfig {
@@ -78,7 +78,7 @@ if (t) {
 
 // Decoder for HTML entities
 function decodeHtmlEntities(text: string): string {
-  if (!text) return '';
+  if (!text) return "";
   return decode(text);
 }
 
@@ -103,7 +103,12 @@ const description = `Luister ${showName} van ${showDate.toLocaleDateString("NL",
 
 <Layout brandColor={stationColor}>
   <title slot="head">{title}</title>
-  <script slot="head" defer event-station={stationName} event-program={showName} src="https://stats.zuidwesttv.nl/js/script.pageview-props.js"></script>
+  <script
+    slot="head"
+    defer
+    event-station={stationName}
+    event-program={showName}
+    src="https://stats.zuidwesttv.nl/js/script.pageview-props.js"></script>
   <meta slot="head" name="description" content={description} />
   <meta slot="head" property="og:title" content={`📻 ${title}`} />
   <meta slot="head" property="og:description" content={description} />
@@ -312,11 +317,13 @@ const description = `Luister ${showName} van ${showDate.toLocaleDateString("NL",
   };
 
   const initPlayer = () => {
-    audio.currentTime = audio.dataset.startTime
-      ? Number(audio.dataset.startTime)
-      : 0;
+    if (!userHasSeeked) {
+      audio.currentTime = audio.dataset.startTime
+        ? Number(audio.dataset.startTime)
+        : 0;
+      seekSlider.value = "" + Math.floor(audio.currentTime);
+    }
     seekSlider.max = "" + Math.floor(audio.duration);
-    seekSlider.value = "" + Math.floor(audio.currentTime);
     updateCurrentTime();
     durationContainer.textContent = calculateTime(audio.duration);
   };
@@ -398,6 +405,7 @@ const description = `Luister ${showName} van ${showDate.toLocaleDateString("NL",
     "js-use-timestamp",
   ) as HTMLInputElement;
   let raf: number | null = null;
+  let userHasSeeked = false;
 
   playIconContainer.addEventListener("click", () => {
     if (audio.paused) {
@@ -439,6 +447,7 @@ const description = `Luister ${showName} van ${showDate.toLocaleDateString("NL",
 
   seekSlider.addEventListener("input", () => {
     updateCurrentTime();
+    userHasSeeked = true;
     if (!audio.paused) {
       if (raf) {
         cancelAnimationFrame(raf);
@@ -448,6 +457,7 @@ const description = `Luister ${showName} van ${showDate.toLocaleDateString("NL",
 
   seekSlider.addEventListener("change", () => {
     audio.currentTime = Number(seekSlider.value);
+    userHasSeeked = true;
     if (!audio.paused) {
       requestAnimationFrame(whilePlaying);
     }


### PR DESCRIPTION
## Summary
- preserve manually selected playback time when audio metadata loads

## Testing
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6840654a6f3483288e9b08c546801900